### PR TITLE
objtool: Improve insn decoding and alternatives handling

### DIFF
--- a/lib/math/div64.c
+++ b/lib/math/div64.c
@@ -25,7 +25,7 @@
 #include <linux/minmax.h>
 #include <linux/log2.h>
 #ifdef CONFIG_RISCV
-#include <linux/objtool.h>>
+#include <linux/objtool.h>
 #endif
 
 /* Not needed on 64bit architectures */

--- a/tools/objtool/arch/riscv/decode.c
+++ b/tools/objtool/arch/riscv/decode.c
@@ -113,10 +113,17 @@ bool arch_pc_relative_reloc(struct reloc *reloc)
 #define RVC_OPCODE_LDSP		0x6002
 #define RVC_OPCODE_JR		0x8002
 #define RVC_OPCODE_SDSP		0xe002
+#define RVC_OPCODE_ADDI16SP_LUI	0x6001
+#define RVC_OPCODE_LD           0x6000
+#define RVC_OPCODE_OTHER        0x8001 // ld lui srli srai andi and or xor sub
 
 #define RVC_EXTRACT_OPCODE(x) \
 	({typeof(x) x_ = (x); \
 	(x_ & RVC_INSN_FUNCT3_MASK) | (x_ & 0x3); })
+
+#define RVC_EXTRACT_OPCODE_11_7(x) \
+	({typeof(x) x_ = (x); \
+    (RVC_X(x_, 7, GENMASK(4, 0))); })
 
 #define RVC_EXTRACT_C0_RD_REG(x) \
 	({typeof(x) x_ = (x); \
@@ -386,10 +393,18 @@ static void insn_decode2(struct insn *ins, u16 code,
 		break;
 
 	/* sp op pattern 2/2: c.addi16sp */
-	case RVC_OPCODE_ADDI16SP:
-		if (RVC_EXTRACT_CI_RD_REG(code) == CFI_SP) {
-			ins->imm = RVC_EXTRACT_ADDI16SP_IMM(code);
-			ins->code = RV_CODE_SP_ADDI;
+	case RVC_OPCODE_ADDI16SP_LUI:
+		rd = RVC_EXTRACT_CI_RD_REG(code);
+		if (RVC_EXTRACT_OPCODE_11_7(code) != 0x2) { // c.lui
+			if (rd == CFI_SP || rd == CFI_BP) {
+				ins->code = RV_CODE_SP_HINT;
+				ins->reg = rd;
+			}
+		} else { // c.addi16sp
+			if (rd == CFI_SP) {
+				ins->imm = RVC_EXTRACT_ADDI16SP_IMM(code);
+				ins->code = RV_CODE_SP_ADDI;
+			}
 		}
 		break;
 
@@ -472,7 +487,15 @@ static void insn_decode2(struct insn *ins, u16 code,
 		}
 		break;
 
-	/* TODO: ld lui srli srai andi and or xor sub */
+	case RVC_OPCODE_OTHER:
+	case RVC_OPCODE_LD:
+		rd = RVC_EXTRACT_CI_RD_REG(code);
+		if (rd == CFI_BP) { // CFI_SP cannot be assigned to rd
+			ins->code = RV_CODE_SP_HINT;
+			ins->reg = rd;
+		}
+		break;
+		
 	case RVC_OPCODE_ADDIW:
 	case RVC_OPCODE_LI:
 	case RVC_OPCODE_SLLI:

--- a/tools/objtool/special.c
+++ b/tools/objtool/special.c
@@ -88,24 +88,32 @@ static int get_alt_entry(struct elf *elf, const struct special_entry *entry,
 	alt->jump_or_nop = entry->jump_or_nop;
 
 	if (alt->group) {
-		alt->orig_len = *(unsigned char *)(sec->data->d_buf + offset +
-						   entry->orig_len);
-		alt->new_len = *(unsigned char *)(sec->data->d_buf + offset +
-						  entry->new_len);
-		/*
-		 * On RISC-V, new_len should not be 0.
-		 * Try calculate it from relocs which might be ADD16/SUB16 pairs.
-		 */
-		if (alt->new_len == 0 && elf->ehdr.e_machine == EM_RISCV) {
-			struct reloc *radd, *rsub;
-			radd = find_reloc_by_dest(elf, sec, offset + entry->new_len);
-			if (!radd) {
-				WARN_FUNC("can't find new_len", sec, offset + entry->new_len);
-				return -1;
+		/* Here on riscv is u16, while x86 and loongarch are both u8,
+		 * We can look at arch/<arch>/include/asm/alternative.h::struct alt_entry. */ 
+		alt->orig_len =	bswap_if_needed(elf, *(unsigned short *)(sec->data->d_buf + offset +
+									entry->orig_len));
+		alt->new_len = bswap_if_needed(elf, *(unsigned short *)(sec->data->d_buf + offset +
+									entry->new_len));
+
+		if (elf->ehdr.e_machine == EM_RISCV)  {
+			/*
+			* On RISC-V, new_len should not be 0.
+			* Try calculate it from relocs which might be ADD16/SUB16 pairs.
+			*/
+			if (alt->new_len == 0) {
+				struct reloc *radd, *rsub;
+				radd = find_reloc_by_dest(elf, sec, offset + entry->new_len);
+				if (!radd) {
+					WARN_FUNC("can't find new_len", sec, offset + entry->new_len);
+					return -1;
+				}
+				rsub = radd + 1;
+				alt->new_len = radd->sym->offset - rsub->sym->offset;
+				alt->orig_len = alt->new_len;
 			}
-			rsub = radd + 1;
-			alt->new_len = radd->sym->offset - rsub->sym->offset;
-			alt->orig_len = alt->new_len;
+		} else {
+			alt->orig_len =	*(unsigned char *)(sec->data->d_buf + offset + entry->orig_len);
+			alt->new_len = *(unsigned char *)(sec->data->d_buf + offset + entry->new_len);
 		}
 	}
 


### PR DESCRIPTION
1. [Fix: remove extra '>' in div64.c](https://github.com/laokz/linux/commit/a5b552c0578ba8a651f2ba5b55ebe07cc88e4620)
2. [riscv: add other insn's decode](https://github.com/laokz/linux/commit/386ba6e5a99b83f4ad94e4cdc87eb011b7d21033)
3. [objtool: expand alternative block limits for riscv](https://github.com/laokz/linux/commit/57f29e8ebe5b74c032329639fc2a20cb544dd58a)